### PR TITLE
shop: sidebar + proudct card + breadcrumb

### DIFF
--- a/outfairy/src/app/globals.css
+++ b/outfairy/src/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Noto Serif TC', sans-serif;
 }

--- a/outfairy/src/app/shop/page.js
+++ b/outfairy/src/app/shop/page.js
@@ -1,7 +1,21 @@
 import Image from "next/image";
+import Breadcrumb from "@/components/Breadcrumb";
+import Sidebar from "@/components/Sidebar";
+import Grid from "@/components/Grid";
+import { products } from "@/data/Data";
 
-export default function shop() {
+export default function Shop() {
   return (
-    <div>Shop</div>
+    <main className="px-10 mt-[62px]">
+  <Breadcrumb />
+  <div className="flex items-start">
+    <Sidebar />
+    <div className="flex-1 max-w-7xl mx-auto">
+      <Grid products={products} />
+    </div>
+  </div>
+</main>
+
   );
 }
+

--- a/outfairy/src/components/Breadcrumb.js
+++ b/outfairy/src/components/Breadcrumb.js
@@ -1,0 +1,36 @@
+"use client";
+
+import { SlidersHorizontal } from "lucide-react";
+import Link from "next/link";
+
+export default function Breadcrumb() {
+  return (
+    <div className="flex items-center justify-between py-15">
+      
+      {/* 左半：回上頁 + 麵包屑 */}
+      <div className="flex items-center gap-8">
+        <button
+          onClick={() => window.history.back()}
+          className="text-black text-xl font-semibold hover:underline"
+        >
+          回上頁
+        </button>
+
+        {/* 麵包屑 */}
+        <div className="flex items-center ml-40 gap-1 text-xl">
+          <Link href="/" className="text-black font-semibold text-2xl hover:underline">
+            首頁
+          </Link>
+          <span className="text-black">/</span>
+          <span className="text-[#ac8a46] font-semibold text-2xl">女裝</span>
+        </div>
+      </div>
+
+      {/* 右半：篩選按鈕 */}
+      <button className="flex items-center gap-1 text-black font-semibold hover:underline">
+        <span>篩選</span>
+        <SlidersHorizontal className="w-5 h-5" />
+      </button>
+    </div>
+  );
+}

--- a/outfairy/src/components/Card.js
+++ b/outfairy/src/components/Card.js
@@ -1,0 +1,21 @@
+import { Heart, ShoppingCart } from "lucide-react";
+
+export default function Card({ product }) {
+  return (
+    <div className="bg-[#fbf8f4] rounded-xl w-full aspect-[262.59/392.49] overflow-hidden shadow-sm hover:shadow-md transition flex flex-col">
+      <div className="bg-[#d9d9d9] w-full aspect-[262.59/279] rounded-t-xl"></div>
+
+      <div className="flex flex-col justify-between flex-1 px-2 pb-2">
+        <h3 className="mt-[11.21px] text-base text-black">{product.name}</h3>
+        <div className="my-[11.21px] flex items-center justify-between">
+          <p className="text-black">${product.price}</p>
+          <div className="flex gap-3 text-black">
+            <Heart className="w-5 h-5" />
+            <ShoppingCart className="w-5 h-5" />
+          </div>
+       </div>
+      </div>
+    </div>
+
+  );
+}

--- a/outfairy/src/components/Grid.js
+++ b/outfairy/src/components/Grid.js
@@ -1,0 +1,14 @@
+import Card from "./Card";
+
+export default function Grid({ products }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
+      {products.map((product) => (
+        <div key={product.id}>
+          <Card product={product} />
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/outfairy/src/components/Sidebar.js
+++ b/outfairy/src/components/Sidebar.js
@@ -1,0 +1,133 @@
+
+
+export default function Sidebar() {
+    return (
+      <aside className="w-64 pb-4 pl-3 text-black space-y-6">
+        <div>
+          <h2 className="mb-2">新品上市</h2>
+          <ul className="space-y-1 pl-4 list-disc list-inside">
+            <li>檢視全部</li>
+            <li>服飾</li>
+            <li>運動服飾</li>
+            <li>鞋品及配飾</li>
+            <li>內衣和睡衣</li>
+            <li>流行趨勢</li>
+          </ul>
+        </div>
+  
+        <div>
+          <h2 className="mb-2">洋裝</h2>
+          <ul className="space-y-1 pl-4 list-disc list-inside">
+            <li>單肩洋裝</li>
+            <li>露背洋裝</li>
+            <li>鏤空洋裝</li>
+            <li>無袖洋裝</li>
+            <li>泡泡袖洋裝</li>
+            <li>綁頸洋裝</li>
+            <li>婚禮賓客洋裝</li>
+            <li>A 字洋裝</li>
+            <li>細肩帶洋裝</li>
+            <li>針織洋裝</li>
+            <li>細肩帶洋裝</li>
+            <li>長袖洋裝</li>
+            <li>細肩帶洋裝</li>
+            <li>亞麻洋裝</li>
+            <li>T 恤式洋裝</li>
+            <li>丹寧洋裝</li>
+            <li>短洋裝</li>
+            <li>中長洋裝</li>
+            <li>長洋裝</li>
+            <li>海灘洋裝</li>
+            <li>貼身連身裙／洋裝</li>
+            <li>派對連身裙／洋裝</li>
+            <li>伴娘洋裝</li>
+            <li>連身小洋裝</li>
+            <li>晚間洋裝</li>
+            <li>蕾絲洋裝</li>
+            <li>襯衫式洋裝</li>
+            <li>亮片洋裝</li>
+            <li>裹身洋裝</li>
+            <li>傘狀洋裝</li>
+            <li>毛衣洋裝</li>
+            <li>卡弗坦洋裝</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 className="mb-2">上衣</h2>
+          <ul className="space-y-1 pl-4 list-disc list-inside">
+            <li>基本款</li>
+            <li>短裙</li>
+            <li>運動</li>
+            <li>家居服</li>
+            <li>孕婦裝</li>
+            <li>針織系列</li>
+            <li>襯衫和罩衫</li>
+            <li>外套和大衣</li>
+            <li>運動衫與連帽衫</li>
+            <li>泳衣和海灘服裝</li>
+            <li>週邊與圖案系列</li>
+            <li>西裝外套和西裝背心</li>
+          </ul>
+        </div>
+        
+        <div>
+         <h2 className="mb-2">下裝</h2>
+         <ul className="space-y-1 pl-4 list-disc list-inside">
+            <li>長褲</li>
+            <li>牛仔褲</li>
+            <li>短褲</li>
+            <li>內衣褲</li>
+            <li>短襪及襪褲</li>
+            <li>連身褲與連身褲裝</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 className="mb-2">配件</h2>
+          <ul className="space-y-1 pl-4 list-disc list-inside">
+            <li>查看所有</li>
+            <li>袋</li>
+            <li>首飾</li>
+            <li>皮帶</li>
+            <li>手套</li>
+            <li>帽子</li>
+            <li>圍巾</li>
+            <li>太陽眼鏡</li>
+            <li>頭髮配飾</li>
+            <li>狗狗服飾與配件</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 className="mb-2">鞋子</h2>
+          <ul className="space-y-1 pl-4 list-disc list-inside">
+            <li>查看所有</li>
+            <li>靴子</li>
+            <li>涼鞋</li>
+            <li>拖鞋</li>
+            <li>運動鞋</li>
+            <li>草編鞋</li>
+            <li>平底鞋</li>
+            <li>高跟鞋</li>
+            <li>樂福鞋</li>
+            <li>穆勒鞋</li>
+            <li>露跟鞋</li>
+            <li>芭蕾舞鞋</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 className="mb-2">運動</h2>
+          <ul className="space-y-1 pl-4 list-disc list-inside">
+            <li>查看所有</li>
+            <li>新品上市</li>
+            <li>運動內衣</li>
+            <li>內搭褲和緊身褲</li>
+          </ul>
+        </div>
+
+      </aside>
+    );
+  }
+  

--- a/outfairy/src/data/Data.js
+++ b/outfairy/src/data/Data.js
@@ -1,0 +1,159 @@
+export const products = [
+    {
+      id: 1,
+      name: "休閒闊腿褲",
+      price: 120,
+    },
+    {
+        id: 2,
+        name: "休閒闊腿褲",
+        price: 120,
+      },
+
+      {
+        id: 3,
+        name: "休閒闊腿褲",
+        price: 120,
+      },
+      
+      {
+        id: 4,
+        name: "休閒闊腿褲",
+        price: 120,
+      },
+
+      {
+        id: 5,
+        name: "休閒闊腿褲",
+        price: 120,
+      },
+      {
+        id: 6,
+        name: "休閒闊腿褲",
+        price: 120,
+      },
+      {
+          id: 7,
+          name: "休閒闊腿褲",
+          price: 120,
+        },
+  
+        {
+          id: 8,
+          name: "休閒闊腿褲",
+          price: 120,
+        },
+        
+        {
+          id: 9,
+          name: "休閒闊腿褲",
+          price: 120,
+        },
+  
+        {
+          id: 10,
+          name: "休閒闊腿褲",
+          price: 120,
+        },
+        
+      {
+        id: 11,
+        name: "休閒闊腿褲",
+        price: 120,
+      },
+      {
+          id: 12,
+          name: "休閒闊腿褲",
+          price: 120,
+        },
+
+        {
+          id: 13,
+          name: "休閒闊腿褲",
+          price: 120,
+        },
+        
+        {
+          id: 14,
+          name: "休閒闊腿褲",
+          price: 120,
+        },
+
+        {
+          id: 15,
+          name: "休閒闊腿褲",
+          price: 120,
+        },
+        {
+          id: 16,
+          name: "休閒闊腿褲",
+          price: 120,
+        },
+        {
+            id: 17,
+            name: "休閒闊腿褲",
+            price: 120,
+          },
+    
+          {
+            id: 18,
+            name: "休閒闊腿褲",
+            price: 120,
+          },
+          
+          {
+            id: 19,
+            name: "休閒闊腿褲",
+            price: 120,
+          },
+    
+          {
+            id: 20,
+            name: "休閒闊腿褲",
+            price: 120,
+          },
+          {
+            id: 21,
+            name: "休閒闊腿褲",
+            price: 120,
+          },
+          {
+              id: 22,
+              name: "休閒闊腿褲",
+              price: 120,
+            },
+      
+            {
+              id: 23,
+              name: "休閒闊腿褲",
+              price: 120,
+            },
+            
+            {
+              id: 24,
+              name: "休閒闊腿褲",
+              price: 120,
+            },
+      
+            {
+              id: 25,
+              name: "休閒闊腿褲",
+              price: 120,
+            },
+            {
+              id: 26,
+              name: "休閒闊腿褲",
+              price: 120,
+            },
+            {
+                id: 27,
+                name: "休閒闊腿褲",
+                price: 120,
+              },
+        
+              {
+                id: 28,
+                name: "休閒闊腿褲",
+                price: 120,
+              },
+  ];


### PR DESCRIPTION
- 字體統一使用 "Noto Serif TC"
- 完成商品卡片排版（包含 hover 效果、圖片比例固定）
- 新增 Breadcrumb，包含「回上頁 / 首頁 / 女裝」導覽
- 完成 Sidebar 分類區
- 加入篩選按鈕，與 Breadcrumb 區塊左右對齊
- 商品卡片區採 RWD，不同螢幕尺寸下都能維持排版一致

---

如果有需要調整的地方再跟我說，感謝～🥹🙏